### PR TITLE
Align CHANGELOG.md with common format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,38 +1,4 @@
-# Change Log
-All notable changes to the "solargraph" extension will be documented in this file.
-
-## 0.0.1
-- Initial release
-
-## 0.0.2
-- Updated README and package metadata (author, keywords, etc.)
-- Added icon
-- Reduced console output
-
-## 0.1.0
-- Check for Solargraph gem updates
-- Use server instead of command line for better performance
-- Serial files are no longer used
-
-## 0.1.1
-- Minor documentation updates
-
-## 0.2.2
-- Kill Solargraph server process on deactivation
-
-## 0.2.3
-- Documentation for the @type tag
-
-## 0.2.4
-- Trigger workspace refresh on file saves. (This eliminates the need for the server's constant_updates thread.)
-
-## 0.2.5
-- Solargraph server manages the workspace yardoc.
-
-## 0.2.6
-- Setting to choose whether the gem includes snippets in suggestions. Defaults to false.
-
-## 0.3.0
+## 0.3.0 – May 24th, 2017
 - Only set CompletionItem.insertText to SnippetString if suggestion kind is Snippet.
 - Arguments removed from CompletionItem labels.
 - Signature help for method arguments.
@@ -40,3 +6,34 @@ All notable changes to the "solargraph" extension will be documented in this fil
 - Display popup documentation on hover with links to documentation.
 - Code completion detail includes arguments for methods.
 - Code analysis notifications in status bar.
+
+## 0.2.6
+- Setting to choose whether the gem includes snippets in suggestions. Defaults to false.
+
+## 0.2.5
+- Solargraph server manages the workspace yardoc.
+
+## 0.2.4
+- Trigger workspace refresh on file saves. (This eliminates the need for the server's constant_updates thread.)
+
+## 0.2.3
+- Documentation for the @type tag
+
+## 0.2.2
+- Kill Solargraph server process on deactivation
+
+## 0.1.1
+- Minor documentation updates
+
+## 0.1.0
+- Check for Solargraph gem updates
+- Use server instead of command line for better performance
+- Serial files are no longer used
+
+## 0.0.2
+- Updated README and package metadata (author, keywords, etc.)
+- Added icon
+- Reduced console output
+
+## 0.0.1
+- Initial release


### PR DESCRIPTION
This reverses the order of releases in the Change Log, putting the most recent at the top. This is how it's usually done, because it makes it easier for people to quickly check what has changed.