### PR TITLE
do not set solargraph.bundlerPath as executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
                 "solargraph.commandPath": {
                     "type": "string",
                     "default": "solargraph",
-                    "description": "Path to the solargraph command.  Set this to an absolute path to select from multiple installed Ruby versions.",
-                    "isExecutable": true
+                    "description": "Path to the solargraph command.  Set this to an absolute path to select from multiple installed Ruby versions."
                 },
                 "solargraph.useBundler": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
                 "solargraph.bundlerPath": {
                     "type": "string",
                     "description": "Path to the bundle executable, defaults to 'bundle'",
-                    "default": "bundle",
-                    "isExecutable": true
+                    "default": "bundle"
                 },
                 "solargraph.checkGemVersion": {
                     "type": "boolean",


### PR DESCRIPTION
This allows the user to set the property on a per-workspace level