### PR TITLE
Add spinner to 'Starting the Solargraph language server' message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "solargraph",
-    "version": "0.18.1",
+    "version": "0.19.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -451,6 +451,11 @@
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
             }
+        },
+        "elegant-spinner": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+            "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
         },
         "end-of-stream": {
             "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -275,6 +275,7 @@
         "vscode": "^1.1.22"
     },
     "dependencies": {
+        "elegant-spinner": "^1.0.1",
         "html2plaintext": "^1.1.0",
         "solargraph-utils": "^0.8.2",
         "vscode-languageclient": "^5.0.1",

--- a/src/language-client.ts
+++ b/src/language-client.ts
@@ -3,6 +3,11 @@ import * as net from 'net';
 import { Hover, MarkdownString } from 'vscode';
 import * as solargraph from 'solargraph-utils';
 import * as vscode from 'vscode';
+import * as elegantSpinner from 'elegant-spinner';
+
+const frame = elegantSpinner();
+const prepareStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+prepareStatus.show();
 
 //export function makeLanguageClient(socketProvider: solargraph.SocketProvider): LanguageClient {
 export function makeLanguageClient(configuration: solargraph.Configuration): LanguageClient {
@@ -87,7 +92,7 @@ export function makeLanguageClient(configuration: solargraph.Configuration): Lan
 						resolve({
 							reader: socket,
 							writer: socket
-						});	
+						});
 					}).catch((err) => {
 						// TODO Handle error
 						// console.log('Failed to start language server: ' + JSON.stringify(err));
@@ -127,7 +132,10 @@ export function makeLanguageClient(configuration: solargraph.Configuration): Lan
 	let serverOptions: ServerOptions = selectClient();
 
 	let client = new LanguageClient('Ruby Language Server', serverOptions, clientOptions);
-	let prepareStatus = vscode.window.setStatusBarMessage('Starting the Solargraph language server...');
+	setInterval(() => {
+		prepareStatus.text = `Starting the Solargraph language server ${frame()}`
+	}, 100)
+	// let prepareStatus = vscode.window.setStatusBarMessage(`Starting the Solargraph language server ${frame()}`);
 	client.onReady().then(() => {
 		prepareStatus.dispose();
 		vscode.window.setStatusBarMessage('Solargraph is ready.', 3000);

--- a/src/language-client.ts
+++ b/src/language-client.ts
@@ -135,7 +135,6 @@ export function makeLanguageClient(configuration: solargraph.Configuration): Lan
 	setInterval(() => {
 		prepareStatus.text = `Starting the Solargraph language server ${frame()}`
 	}, 100)
-	// let prepareStatus = vscode.window.setStatusBarMessage(`Starting the Solargraph language server ${frame()}`);
 	client.onReady().then(() => {
 		prepareStatus.dispose();
 		vscode.window.setStatusBarMessage('Solargraph is ready.', 3000);


### PR DESCRIPTION
This is mostly just an example for you to use if you want. In my opinion, I would prefer to see some kind of spinner so I know that activity is happening. A progress bar/some kind of progress tracker would be even better if that's possible.

![kapture 2019-01-16 at 15 43 56](https://user-images.githubusercontent.com/7546899/51283714-5605d880-19a6-11e9-9c2f-54a66bfcca39.gif)