### PR TITLE
Added clarity for Bundler setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Run `bundle install` and use `bundle exec yard gems` to generate the documentati
 
 In order to access intellisense for bundled gems, you'll need to start the language server with Bundler by setting the `solargraph.useBundler` option to `true`.
 
+> Note: solargraph.bundlerPath should be an absolute path to bundler executable.
+
 ### Diagnostics (Linting)
 
 To enable diagnostics, set the `solargraph.diagnostics` configuration to `true`.

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
                 },
                 "solargraph.bundlerPath": {
                     "type": "string",
-                    "description": "Path to the bundle executable, defaults to 'bundle'",
+                    "description": "Path to the bundle executable, defaults to 'bundle'. Needs to be an absolute path for the 'bundle' exec/shim",
                     "default": "bundle",
                     "scope": "resource"
                 },


### PR DESCRIPTION
Improved documentation around Bundler setup. `solargraph.bundlerPath` needs to have absolute path to the `bundle` executable or shim.

Branch: "bundler_doc_improvement" | Commit Type: "Enhancement" | Changes tested: "yes"