### PR TITLE
A few external server/docker improvements

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -89,19 +89,11 @@ export function activate(context: vscode.ExtensionContext) {
 		context.subscriptions.push(disposableClient);
 	};
 
-	var restartLanguageServer = function (): Promise<void> {
-		return new Promise((resolve) => {
-			if (languageClient) {
-				languageClient.stop().then(() => {
-					disposableClient.dispose();
-					startLanguageServer();
-					resolve();
-				});
-			} else {
-				startLanguageServer();
-				resolve();
-			}
-		});
+	var restartLanguageServer = function (): void {
+		if (disposableClient) {
+			disposableClient.dispose();
+		}
+		startLanguageServer();
 	};
 
 	// Open URL command (used internally for browsing documentation pages)
@@ -115,9 +107,8 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Restart command
 	var disposableRestart = vscode.commands.registerCommand('solargraph.restart', () => {
-		restartLanguageServer().then(() => {
-			vscode.window.showInformationMessage('Solargraph server restarted.');
-		});
+		restartLanguageServer();
+		vscode.window.showInformationMessage('Solargraph server restarted.');
 	});
 	context.subscriptions.push(disposableRestart);
 

--- a/src/language-client.ts
+++ b/src/language-client.ts
@@ -101,11 +101,17 @@ export function makeLanguageClient(configuration: solargraph.Configuration): Lan
 			};
 		} else {
 			return () => {
-				return new Promise((resolve) => {
+				return new Promise((resolve, reject) => {
 					let socket: net.Socket = net.createConnection({ host: vscode.workspace.getConfiguration('solargraph').externalServer.host, port: vscode.workspace.getConfiguration('solargraph').externalServer.port });
-					resolve({
-						reader: socket,
-						writer: socket
+					socket.addListener("connect", () => {
+					socket.removeAllListeners();
+						resolve({
+							reader: socket,
+							writer: socket
+						});
+					});
+					socket.addListener("error", (err) => {
+						reject(err);
 					});
 				});
 			};


### PR DESCRIPTION
Meant to address parts of #197. This improves the handling of the external server a bit.

The first commit fixes the restart command not working after the startup of the language server failed because the external server was not yet available. This is more of a bandaid fix, the actual issue is addressed in the second commit.

The second commit fixes the actual hangup of the extension. This was caused by the extension sending a shutdown command to the external server. But since the external server isn't available anymore this hangs. Indefinitely it seems. Work around this by only stopping the client when it is not stopped already. This is achieved by just calling the dispose method, which checks the current state of the client and calls stop accordingly. This now happens asynchronously, which I don't believe is a problem. If is is though, feel free to remove this commit entierly. The trigger of this issue is already fixed with the first commit.

The third commit adds a handy notification asking the user if they want to try connecting again if the connection fails on startup. 
![image](https://user-images.githubusercontent.com/14981592/186745606-19688a9b-4248-4334-8106-91ec8c09e255.png)
I did not add automatic retrying, and it only works for the inital aquisition of the socket. I have no idea how to gracefully handle a connection loss after the inital connection has already been established, but it should certainly be an improvement to how it is currently.

Thanks for creating such an useful extension, I really appreciate it!