### PR TITLE
Enable String as Input for Port Config

### DIFF
--- a/src/language-client.ts
+++ b/src/language-client.ts
@@ -102,7 +102,7 @@ export function makeLanguageClient(configuration: solargraph.Configuration): Lan
 		} else {
 			return () => {
 				return new Promise((resolve) => {
-					let socket: net.Socket = net.createConnection({ host: vscode.workspace.getConfiguration('solargraph').externalServer.host, port: vscode.workspace.getConfiguration('solargraph').externalServer.port });
+					let socket: net.Socket = net.createConnection({ host: vscode.workspace.getConfiguration('solargraph').externalServer.host, port: parseInt(vscode.workspace.getConfiguration('solargraph').externalServer.port) });
 					resolve({
 						reader: socket,
 						writer: socket


### PR DESCRIPTION
Proposed Solution for #256.
This enables to pass both a Number and a String into the Port Configuration.
Numbers can't be created from a Environment Variable inside a `settings.json`, that's why its useful to be able to configure it with a String instead of a Number.